### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ find a PyPI package that did this without problems.
 Documentation
 -------------
 
-The full documentation is at http://alotofeffort.rtfd.org.
+The full documentation is at https://alotofeffort.readthedocs.io.
 
 Quickstart
 ----------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
